### PR TITLE
fix scrim on collapsed statuses with a media preview

### DIFF
--- a/app/javascript/flavours/glitch/styles/mastodon-donphan.scss
+++ b/app/javascript/flavours/glitch/styles/mastodon-donphan.scss
@@ -216,3 +216,17 @@ $account-background-color: white;
   }
 }
 
+
+// Make scrim white on collapsed statuses with a media preview
+.status.collapsed.has-background::before {
+  background-image: linear-gradient(180deg,
+    rgba(255, 255, 255, .75),
+    rgba(255, 255, 255, .65) 24px,
+    rgba(255, 255, 255, .8)
+  );
+}
+
+// Fix goofy gradient on collapsed statuses with a media preview
+.status.collapsed.has-background .status__content {
+  mix-blend-mode: multiply;
+}


### PR DESCRIPTION
Before:
![localhost_3000_web_timelines_home 4](https://user-images.githubusercontent.com/315139/44553906-5c619280-a72f-11e8-8e44-0eeacaf0b0c9.png)

After:
![localhost_3000_web_timelines_home 5](https://user-images.githubusercontent.com/315139/44553894-54095780-a72f-11e8-8b19-a8fea407aecd.png)

Names and buttons are still barely visible but that's an upstream problem